### PR TITLE
Add ecommerce boilerplate with routing and context

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://mi-backend.com/api

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "dbstore-front",
       "version": "0.0.0",
       "dependencies": {
+        "@mercadopago/sdk-react": "^1.0.3",
+        "@react-oauth/google": "^0.12.2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -696,6 +699,35 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@mercadopago/sdk-js": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mercadopago/sdk-js/-/sdk-js-0.0.3.tgz",
+      "integrity": "sha512-kO48DNLHdfFAp3on12nuKdqNlEmw1x3+nM6wLd04BdWOXoFcAhkNMQV3AyUIanXdO/bB/dENakdacLT29297EQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mercadopago/sdk-react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@mercadopago/sdk-react/-/sdk-react-1.0.3.tgz",
+      "integrity": "sha512-LSCNt6VqAXobIcT5bX7VRXupyB34WFKmR5tHFaC44ajoGse6b5r7WCZ+RCVxbuGwieLG1UJxxDGSQOXy+2M0Sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mercadopago/sdk-js": "^0.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1393,6 +1425,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2179,6 +2220,44 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2233,6 +2312,12 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mercadopago/sdk-react": "^1.0.3",
+    "@react-oauth/google": "^0.12.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,35 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { GoogleOAuthProvider } from '@react-oauth/google'
+import HomePage from './pages/HomePage'
+import ProductPage from './pages/ProductPage'
+import CartPage from './pages/CartPage'
+import LoginPage from './pages/LoginPage'
+import RegisterPage from './pages/RegisterPage'
+import DashboardPage from './pages/DashboardPage'
+import AdminPage from './pages/AdminPage'
+import { UserProvider } from './context/UserContext'
+import { CartProvider } from './context/CartContext'
 import './App.css'
 
 function App() {
-
   return (
-    <>
-      <h1>Holaaa</h1>
-    </>
+    <GoogleOAuthProvider clientId="GOOGLE_CLIENT_ID">
+      <UserProvider>
+        <CartProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/producto/:id" element={<ProductPage />} />
+              <Route path="/carrito" element={<CartPage />} />
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/registro" element={<RegisterPage />} />
+              <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/admin" element={<AdminPage />} />
+            </Routes>
+          </BrowserRouter>
+        </CartProvider>
+      </UserProvider>
+    </GoogleOAuthProvider>
   )
 }
 

--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, useState } from 'react'
+
+const CartContext = createContext([])
+
+export function CartProvider({ children }) {
+  const [cart, setCart] = useState([])
+
+  const addItem = item => setCart(prev => [...prev, item])
+  const removeItem = id => setCart(prev => prev.filter(i => i.id !== id))
+  const clearCart = () => setCart([])
+
+  return (
+    <CartContext.Provider value={{ cart, addItem, removeItem, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  )
+}
+// eslint-disable-next-line react-refresh/only-export-components
+export const useCart = () => useContext(CartContext)

--- a/src/context/UserContext.jsx
+++ b/src/context/UserContext.jsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, useState } from 'react'
+
+const UserContext = createContext(null)
+
+export function UserProvider({ children }) {
+  const [user, setUser] = useState(null)
+  const login = userData => setUser(userData)
+  const logout = () => setUser(null)
+  return (
+    <UserContext.Provider value={{ user, login, logout }}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useUser = () => useContext(UserContext)

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,0 +1,8 @@
+export default function AdminPage() {
+  return (
+    <div>
+      <h2>Admin</h2>
+      <p>Dashboard de administración</p>
+    </div>
+  )
+}

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -1,0 +1,30 @@
+import { useCart } from '../context/CartContext'
+import { initMercadoPago, Wallet } from '@mercadopago/sdk-react'
+import { useEffect } from 'react'
+
+export default function CartPage() {
+  const { cart, removeItem, clearCart } = useCart()
+
+  useEffect(() => {
+    initMercadoPago('TEST_PUBLIC_KEY')
+  }, [])
+
+  const total = cart.reduce((sum, i) => sum + i.price, 0)
+
+  return (
+    <div>
+      <h2>Carrito</h2>
+      <ul>
+        {cart.map(item => (
+          <li key={item.id}>
+            {item.name} - ${item.price}
+            <button onClick={() => removeItem(item.id)}>Quitar</button>
+          </li>
+        ))}
+      </ul>
+      <p>Total: ${total}</p>
+      <button onClick={clearCart}>Vaciar</button>
+      <Wallet initialization={{ preferenceId: 'YOUR_PREFERENCE_ID' }} />
+    </div>
+  )
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,11 @@
+import { useUser } from '../context/UserContext'
+
+export default function DashboardPage() {
+  const { user } = useUser()
+  return (
+    <div>
+      <h2>Mi cuenta</h2>
+      {user ? <pre>{JSON.stringify(user)}</pre> : <p>No logueado</p>}
+    </div>
+  )
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../services/api'
+
+export default function HomePage() {
+  const [products, setProducts] = useState([])
+
+  useEffect(() => {
+    apiFetch('/products').then(setProducts).catch(() => {})
+  }, [])
+
+  return (
+    <div>
+      <h2>Productos</h2>
+      <ul>
+        {products.map(p => (
+          <li key={p.id}>
+            <Link to={`/producto/${p.id}`}>{p.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,12 @@
+import { GoogleLogin } from '@react-oauth/google'
+import { useUser } from '../context/UserContext'
+
+export default function LoginPage() {
+  const { login } = useUser()
+  return (
+    <div>
+      <h2>Login</h2>
+      <GoogleLogin onSuccess={cred => login(cred)} onError={() => {}} />
+    </div>
+  )
+}

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { apiFetch } from '../services/api'
+import { useCart } from '../context/CartContext'
+
+export default function ProductPage() {
+  const { id } = useParams()
+  const [product, setProduct] = useState(null)
+  const { addItem } = useCart()
+
+  useEffect(() => {
+    apiFetch(`/products/${id}`).then(setProduct).catch(() => {})
+  }, [id])
+
+  if (!product) return <p>Cargando...</p>
+
+  return (
+    <div>
+      <h2>{product.name}</h2>
+      <p>{product.description}</p>
+      <button onClick={() => addItem(product)}>Agregar al carrito</button>
+    </div>
+  )
+}

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -1,0 +1,8 @@
+export default function RegisterPage() {
+  return (
+    <div>
+      <h2>Registro</h2>
+      <p>Formulario de registro...</p>
+    </div>
+  )
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,10 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export async function apiFetch(endpoint, options = {}) {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add `.env` for base API url
- install router and auth dependencies
- configure routes and providers
- add global contexts for user and cart
- create basic page components
- centralize API fetch helper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d33ca84688324b8c4fe63cc1dcb88